### PR TITLE
Retrieve data from stream when decoding WebSocket frame

### DIFF
--- a/src/http/handler/websocket.rs
+++ b/src/http/handler/websocket.rs
@@ -77,7 +77,7 @@ impl Frame {
                 res
             }
             l if l == 0x7e => {
-                let res = usize::from_be_bytes((&raw_data[2..4]).try_into()?);
+                let res = u16::from_be_bytes((&raw_data[2..4]).try_into()?) as usize;
                 pos += 3;
                 res
             }
@@ -312,7 +312,7 @@ impl Handler for WebSocketHandler {
         loop {
             let mut buf = vec![];
             stream.read_buf(&mut buf).await?;
-            let request_frame = Frame::decode(buf)?;
+            let request_frame = Frame::decode(buf).context("Failed to decode frame")?;
             debug!("Decode websocket frame: {:?}", request_frame);
 
             match request_frame {


### PR DESCRIPTION
Decode WebSocket frame from stream not bytes supplied by one `read_buf` call.

It is necessary because single `read` call doesn't always supply all data (particularly when the data is large) even if the all data is packed in one WebSocket frame by sender.

This pull request also adds tests for decoding and encoding large frame.